### PR TITLE
Adjust styling of footer divider to align to figma

### DIFF
--- a/templates/globals/footer.twig
+++ b/templates/globals/footer.twig
@@ -10,7 +10,7 @@
   nonce="r1FXSfeo"></script>
 
 <br />
-<div class="h-5 bg-alf-nav-blue w-auto rounded-t-md"></div>
+<div class="h-5 bg-alf-nav-blue opacity-75 mt-10 w-auto rounded-t-lg"></div>
 
 {# Footer #}
 <footer class="bg-alf-blue">


### PR DESCRIPTION
## Context

There was a misalignment between Figma and the end site for the footer divider.

Fixes: #2 

## Changes

Adjusted the styling of the footer divider